### PR TITLE
Wrapping the platform case with node[:platform] for happiness on Chef11 clients.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-case platform
+case node[:platform]
 when "debian", "ubuntu", "freebsd"
   package "ipmitool" do
     action :install

--- a/recipes/plugin.rb
+++ b/recipes/plugin.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-case platform
+case node[:platform]
 when "debian", "ubuntu", "freebsd"
   package "ipmitool" do
     action :install


### PR DESCRIPTION
The 'case platform' lines in ::default and ::plugin were breaking chef11 clients. I made sure to reference node and things are functioning as expected.
