### PR TITLE
bugfix: this depends on recipe[ohai] having created directories

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,5 @@ version          '0.0.7'
 %w{debian ubuntu freebsd redhat oracle scientific}.each do |os|
   supports os
 end
+
+depends 'ohai'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+include_recipe 'ohai'
+
 case node['platform_family']
 when 'debian', 'freebsd', 'rhel'
   package 'ipmitool' do


### PR DESCRIPTION
Hi there.

In the default recipe, you [depend on the ohai plugin path](https://github.com/Afterglow/chef-ipmi/blob/d462156528a6eadd7e528619e84175e371da136c/recipes/default.rb#L39) to be created.  Since the attribute used actually comes from the ohai cookbook, I suppose this should be included (and, well, it works this way).

Thanks for the cookbook, it's really handy!
Cheers
Stephan
